### PR TITLE
Feat: 주문 취소 api

### DIFF
--- a/src/main/java/com/woojin/ecommerce/common/exception/OrderAccessDeniedException.java
+++ b/src/main/java/com/woojin/ecommerce/common/exception/OrderAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.woojin.ecommerce.common.exception;
+
+import com.woojin.ecommerce.global.exception.ApiException;
+import com.woojin.ecommerce.global.exception.ErrorCode;
+
+public class OrderAccessDeniedException extends ApiException {
+    public OrderAccessDeniedException() {
+        super(ErrorCode.ORDER_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/woojin/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/woojin/ecommerce/controller/OrderController.java
@@ -29,4 +29,13 @@ public class OrderController {
             Pageable pageable) {
         return BaseResponse.ok(orderService.getOrderList(userId, pageable));
     }
+
+    @PatchMapping("/orders/{orderId}/cancel")
+    public BaseResponse<Void> cancelOrder(
+            @PathVariable Long orderId,
+            @RequestHeader("USER-ID") Long userId
+    ) {
+        orderService.cancelOrder(orderId, userId);
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/com/woojin/ecommerce/entity/Order.java
+++ b/src/main/java/com/woojin/ecommerce/entity/Order.java
@@ -1,5 +1,6 @@
 package com.woojin.ecommerce.entity;
 
+import com.woojin.ecommerce.common.exception.OrderAlreadyCanceledException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -43,7 +44,9 @@ public class Order {
     private LocalDateTime canceledAt;
 
     public void cancel() {
-        if (status == OrderStatus.CANCELED) return;
+        if (status == OrderStatus.CANCELED) {
+            throw new OrderAlreadyCanceledException();
+        };
         this.status = OrderStatus.CANCELED;
         this.canceledAt = LocalDateTime.now();
     }

--- a/src/main/java/com/woojin/ecommerce/entity/Product.java
+++ b/src/main/java/com/woojin/ecommerce/entity/Product.java
@@ -49,4 +49,8 @@ public class Product {
         }
         this.stock -= quantity;
     }
+
+    public void increaseStock(int quantity) {
+        this.stock += quantity;
+    }
 }

--- a/src/main/java/com/woojin/ecommerce/global/exception/ErrorCode.java
+++ b/src/main/java/com/woojin/ecommerce/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "존재하지 않는 주문입니다."),
     ORDER_ALREADY_CANCELED(HttpStatus.CONFLICT, "ORDER_ALREADY_CANCELED", "이미 취소된 주문입니다."),
+    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_ACCESS_DENIED", "해당 주문에 대한 권한이 없습니다."),
 
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "INVALID_QUANTITY", "주문 수량은 1개 이상이어야 합니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청 값이 올바르지 않습니다."),


### PR DESCRIPTION
## Issue Number
- #6 

## 작업 내용
- 주문 취소 api
- 주문 취소 시 재고 복구
- orderId가 존재 하지 않을 때 예외 처리
- 이미 취소된 주문을 또 취소하려 할 때 예외 처리
- 주문한 userId가 다를 때 예외 처리

## To Reviewers 
- 주문 취소 성공
<img width="725" height="448" alt="image" src="https://github.com/user-attachments/assets/3c7f09d5-45c8-4fd3-b077-b2cabd216180" />

- 존재하지 않는 orderId
<img width="736" height="451" alt="image" src="https://github.com/user-attachments/assets/2800dfcb-e23b-4f1b-bf78-a06a765017c3" />

- 이미 취소된 주문
<img width="721" height="448" alt="image" src="https://github.com/user-attachments/assets/63190f45-5bef-4eb8-999c-c85ad44068df" />

- 주문한 userId가 다를 때 주문 취소 권한 없음
<img width="715" height="445" alt="image" src="https://github.com/user-attachments/assets/1f8c13fa-7583-428a-8ade-0f636a6021cb" />

## 관련 이슈  
- Closes #6 
